### PR TITLE
Edited Link

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@
         <li>Consult our <a href="https://docs.google.com/document/d/1F3-Z63hQKq1COWwkA5hUrBH7ihQSD4fQ_vRXwid2vuw/edit#heading=h.9leyj5l2w5nt">teaching guide</a>.
         <li>Try doing the exercises yourself and make sure you understand what issues students might run into while doing them.
         <li>After you teach it, report issues and open Pull Requests on <a href="https://github.com/gdisf/teaching-materials">the Github project</a>.
-        <li><a href="https://www.girldevelopit.com/chapters/san-francisco">Let us know</a> about what you taught where.
+        <li><a href="https://www.girldevelopit.com/chapters/san-jose">Let us know</a> about what you taught where.
       </ul>
     </p>
 


### PR DESCRIPTION


# Summary
Changed link for "Tell us About What you Taught" from SJ to SF.


Fixes issue #... 

Here's a description of changes:

* Changed link for "Tell us About What you Taught" from SJ to SF.


cc @gdisf/admins